### PR TITLE
Matlab compatibility fix: clear LD_LIBRARY_PATH for system command

### DIFF
--- a/matlab/ImportHyperLynx.m
+++ b/matlab/ImportHyperLynx.m
@@ -126,7 +126,7 @@ function CSX = ImportHyperLynx(CSX, filename, varargin)
 
   % conversion
   if isunix
-    cmd = [ 'hyp2mat --verbose --output-format csxcad --output pcb.m ' cmdargs ' ''' filename '''' ];
+    cmd = [ 'export LD_LIBRARY_PATH=; hyp2mat --verbose --output-format csxcad --output pcb.m ' cmdargs ' ''' filename '''' ];
   elseif ispc
     m_filename = mfilename('fullpath');
     dir = fileparts( m_filename );


### PR DESCRIPTION
Signed-off-by: Thorsten Liebig Thorsten.Liebig@gmx.de
